### PR TITLE
Feature/property images endpoint

### DIFF
--- a/back/src/main/java/Contest/Project/controllers/PropertyImagesController.java
+++ b/back/src/main/java/Contest/Project/controllers/PropertyImagesController.java
@@ -1,0 +1,48 @@
+package Contest.Project.controllers;
+
+import Contest.Project.entities.Property;
+import Contest.Project.entities.PropertyImages;
+import Contest.Project.services.PropertyImagesService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/RaicesUrbanas/pictures")
+public class PropertyImagesController {
+
+    @Autowired
+    PropertyImagesService propertyImagesService;
+
+
+    @PostMapping("/upload")
+    public ResponseEntity<?> SavePropertyImage(@RequestBody Property property, @RequestBody String url) {
+        try {
+
+            PropertyImages newPropertyImages = propertyImagesService.save(url, property);
+
+            return new ResponseEntity<>( newPropertyImages , HttpStatus.OK);
+
+        } catch (Exception e) {
+
+            System.err.println("Error al procesar la URL: " + e.getMessage());
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+
+        }
+    }
+
+    public ResponseEntity<Object> deleteById(@PathVariable Integer id) {
+        try {
+
+            PropertyImages deletedImage = propertyImagesService.deleteById(id);
+            return ResponseEntity.ok(deletedImage);
+        } catch (IllegalArgumentException e) {
+
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("URL con ID " + id + " no existe.");
+        }
+    }
+
+
+}

--- a/back/src/main/java/Contest/Project/repositories/PropertyImagesRepository.java
+++ b/back/src/main/java/Contest/Project/repositories/PropertyImagesRepository.java
@@ -1,0 +1,7 @@
+package Contest.Project.repositories;
+
+import Contest.Project.entities.PropertyImages;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PropertyImagesRepository extends JpaRepository<PropertyImages,Integer> {
+}

--- a/back/src/main/java/Contest/Project/services/PropertyImagesService.java
+++ b/back/src/main/java/Contest/Project/services/PropertyImagesService.java
@@ -1,0 +1,36 @@
+package Contest.Project.services;
+
+import Contest.Project.entities.Property;
+import Contest.Project.entities.PropertyImages;
+import Contest.Project.repositories.PropertyImagesRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PropertyImagesService {
+
+    @Autowired
+    private PropertyImagesRepository propertyImagesRepository;
+
+    public PropertyImages save(String url, Property property) {
+        PropertyImages propertyImages = PropertyImages.builder()
+                .url(url)
+                .id_property(property)
+                .build();
+
+        return propertyImagesRepository.save(propertyImages);
+    }
+
+    public PropertyImages deleteById(Integer id) {
+        if (propertyImagesRepository.existsById(id)) {
+            PropertyImages register = propertyImagesRepository.findById(id).orElse(null);
+
+            propertyImagesRepository.deleteById(id);
+
+            return register;
+        } else {
+            throw new IllegalArgumentException("URL con ID " + id + " no existe");
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request adds the necessary service and controller logic to manage property images in the application. The new functionalities include uploading and deleting property images, as well as connecting them to their respective properties. The endpoints allow for smooth management of property images through the REST API.

Key changes:

-   PropertyImagesRepository: Created repository interface for managing property images with basic CRUD operations.
-   PropertyImagesService:
-   Added save() method to store a property image with its associated property.
-   Added deleteById() method to remove an image by its ID.

PropertyImagesController:

-   Added a POST endpoint at /RaicesUrbanas/pictures/upload to upload a new property image.
-   Added a DELETE endpoint to remove a property image by its ID.